### PR TITLE
Import setup from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
-from setuptools import find_packages
-
-from distutils.core import setup
+from setuptools import find_packages, setup
 
 version = "0.2.0"
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 
-from distutils.core import setup
-
 from setuptools import find_packages
+
+from distutils.core import setup
 
 version = "0.2.0"
 


### PR DESCRIPTION
setuptools 60 uses its own bunlded version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This is to prepare for Python 3.12, which will drop distutils.

In this case, let's just remove distutils entirely.